### PR TITLE
Fix the code style of all roboteam files

### DIFF
--- a/include/data/RobotParameters.h
+++ b/include/data/RobotParameters.h
@@ -8,15 +8,15 @@
 #include <roboteam_proto/RobotParameters.pb.h>
 
 class RobotParameters {
-public:
-
+   public:
     RobotParameters();
     RobotParameters(double radius, double height, double frontWidth, double dribblerWidth, double angleOffset);
     explicit RobotParameters(const proto::RobotParameters& protoParams);
     [[nodiscard]] proto::RobotParameters toProto() const;
     static RobotParameters from_default();
     static RobotParameters from_rtt2020();
-private:
+
+   private:
     double radius;
     double height;
     double frontWidth;
@@ -24,5 +24,4 @@ private:
     double angleOffset;
 };
 
-
-#endif //RTT_ROBOTPARAMETERS_H
+#endif  // RTT_ROBOTPARAMETERS_H

--- a/include/net/netraw.h
+++ b/include/net/netraw.h
@@ -3,11 +3,10 @@
 
 #include <arpa/inet.h>
 #include <netinet/in.h>
-#include <sys/socket.h>
-#include <sys/types.h>
-
 #include <stdio.h>
 #include <string.h>
+#include <sys/socket.h>
+#include <sys/types.h>
 
 namespace Net {
 

--- a/include/net/robocup_ssl_client.h
+++ b/include/net/robocup_ssl_client.h
@@ -20,13 +20,15 @@
 //========================================================================
 #ifndef ROBOCUP_SSL_CLIENT_H
 #define ROBOCUP_SSL_CLIENT_H
-#include <string>
-#include "netraw.h"
 #include <roboteam_proto/messages_robocup_ssl_detection.pb.h>
 #include <roboteam_proto/messages_robocup_ssl_geometry.pb.h>
 #include <roboteam_proto/messages_robocup_ssl_referee.pb.h>
 #include <roboteam_proto/messages_robocup_ssl_wrapper.pb.h>
 #include <roboteam_proto/messages_robocup_ssl_wrapper_legacy.pb.h>
+
+#include <string>
+
+#include "netraw.h"
 using namespace std;
 /**
         @author Author Name

--- a/include/net/util.h
+++ b/include/net/util.h
@@ -24,6 +24,7 @@
 
 #include <math.h>
 #include <string.h>
+
 #include <algorithm>
 
 // UnusedVar can suppress gcc warnings about unused variables.

--- a/include/observer/Observer.h
+++ b/include/observer/Observer.h
@@ -5,10 +5,10 @@
 #ifndef RTT_OBSERVER_H
 #define RTT_OBSERVER_H
 
-#include <roboteam_proto/messages_robocup_ssl_referee.pb.h>
-#include <roboteam_proto/messages_robocup_ssl_wrapper.pb.h>
 #include <roboteam_proto/RobotData.pb.h>
 #include <roboteam_proto/State.pb.h>
+#include <roboteam_proto/messages_robocup_ssl_referee.pb.h>
+#include <roboteam_proto/messages_robocup_ssl_wrapper.pb.h>
 #include <roboteam_utils/Time.h>
 
 #include "filters/WorldFilter.h"
@@ -24,7 +24,7 @@
  * @author Rolf
  */
 class Observer {
-public:
+   public:
     /**
      * Calls all of the feedbacks for processing relevant data given the given input data.
      * @param time time to extrapolate the world to
@@ -32,12 +32,10 @@ public:
      * @param refereePackets All ofthe packets which were received from the referee.
      *@return The entire known/predicted state of the game at this point in time.
      */
-    proto::State process(Time extrapolatedTo,
-                 const std::vector<proto::SSL_WrapperPacket>& visionPackets,
-                 const std::vector<proto::SSL_Referee>& refereePackets,
-                 std::vector<proto::RobotData> robotData);
+    proto::State process(Time extrapolatedTo, const std::vector<proto::SSL_WrapperPacket> &visionPackets, const std::vector<proto::SSL_Referee> &refereePackets,
+                         std::vector<proto::RobotData> robotData);
 
-private:
+   private:
     RobotParameterDatabase parameterDatabase;
     WorldFilter worldFilter;
     GeometryFilter geometryFilter;
@@ -52,5 +50,4 @@ private:
     void updateReferee(const std::vector<proto::SSL_Referee> &refereePackets);
 };
 
-
-#endif //RTT_OBSERVER_H
+#endif  // RTT_OBSERVER_H

--- a/include/observer/filters/WorldFilter.h
+++ b/include/observer/filters/WorldFilter.h
@@ -7,7 +7,6 @@
 
 #include "BallFilter.h"
 #include "RobotFilter.h"
-
 #include "observer/parameters/RobotParameterDatabase.h"
 
 /**
@@ -29,9 +28,10 @@ class WorldFilter {
      */
     proto::World getWorld();
 
-    void setGeometry(const proto::SSL_GeometryData& geometry);
-    void setRobotParameters(const TwoTeamRobotParameters& parameters);
+    void setGeometry(const proto::SSL_GeometryData &geometry);
+    void setRobotParameters(const TwoTeamRobotParameters &parameters);
     void process(std::vector<proto::SSL_DetectionFrame> visionFrames);
+
    private:
     /** Add a frame to the WorldFilter. This will be forwarded to the relevant filters (ball/robot)
      *  Or they will be created if they do not exist yet. Note this does NOT call the Kalman update/predict equations and thus
@@ -46,7 +46,7 @@ class WorldFilter {
      * @param doLastPredict If set to true, all filters  predict/extrapolate the positions of all objects
      * from the last time they were seen until the time specified.
      * You should always set this to true if you plan on using data immediately.
-      */
+     */
     void update(double time, bool doLastPredict);
     typedef std::map<int, std::vector<std::unique_ptr<RobotFilter>>> robotMap;
     static const std::unique_ptr<RobotFilter> &bestFilter(const std::vector<std::unique_ptr<RobotFilter>> &filters);

--- a/include/observer/filters/geometry/GeometryFilter.h
+++ b/include/observer/filters/geometry/GeometryFilter.h
@@ -5,19 +5,17 @@
 #ifndef RTT_GEOMETRYFILTER_H
 #define RTT_GEOMETRYFILTER_H
 
-
 #include <roboteam_proto/messages_robocup_ssl_geometry.pb.h>
 class GeometryFilter {
-public:
+   public:
     bool process(const proto::SSL_GeometryData& geometryData);
     bool receivedFirstGeometry() const;
     proto::SSL_GeometryData getGeometry() const;
-private:
+
+   private:
     std::string lastGeometryString;
     proto::SSL_GeometryData combinedGeometry;
-    std::map<unsigned int,proto::SSL_GeometryCameraCalibration> cameras;
-
+    std::map<unsigned int, proto::SSL_GeometryCameraCalibration> cameras;
 };
 
-
-#endif //RTT_GEOMETRYFILTER_H
+#endif  // RTT_GEOMETRYFILTER_H

--- a/include/observer/filters/referee/RefereeFilter.h
+++ b/include/observer/filters/referee/RefereeFilter.h
@@ -5,16 +5,16 @@
 #ifndef RTT_REFEREEFILTER_H
 #define RTT_REFEREEFILTER_H
 
-#include <roboteam_utils/Time.h>
 #include <roboteam_proto/messages_robocup_ssl_referee.pb.h>
+#include <roboteam_utils/Time.h>
 class RefereeFilter {
-public:
+   public:
     void process(const std::vector<proto::SSL_Referee> &refereePackets);
     std::optional<proto::SSL_Referee> getLastRefereeMessage() const;
-private:
+
+   private:
     bool firstMessageReceived = false;
     proto::SSL_Referee latestMessage;
 };
 
-
-#endif //RTT_REFEREEFILTER_H
+#endif  // RTT_REFEREEFILTER_H

--- a/include/observer/parameters/RobotParameterDatabase.h
+++ b/include/observer/parameters/RobotParameterDatabase.h
@@ -4,9 +4,9 @@
 
 #ifndef RTT_ROBOTPARAMETERDATABASE_H
 #define RTT_ROBOTPARAMETERDATABASE_H
-#include <roboteam_proto/messages_robocup_ssl_referee.pb.h>
 #include <data/RobotParameters.h>
-struct TwoTeamRobotParameters{
+#include <roboteam_proto/messages_robocup_ssl_referee.pb.h>
+struct TwoTeamRobotParameters {
     bool blueChanged = false;
     bool yellowChanged = false;
     RobotParameters blueParameters;
@@ -15,17 +15,17 @@ struct TwoTeamRobotParameters{
     [[nodiscard]] proto::TeamParameters blueTeamProto() const;
 };
 class RobotParameterDatabase {
-public:
+   public:
     TwoTeamRobotParameters update(const proto::SSL_Referee& refMessage);
     [[nodiscard]] TwoTeamRobotParameters getParams() const;
 
     static RobotParameters getTeamParameters(const std::string& teamName);
-private:
+
+   private:
     std::string blueName;
     RobotParameters blueParameters;
     std::string yellowName;
     RobotParameters yellowParameters;
 };
 
-
-#endif //RTT_ROBOTPARAMETERDATABASE_H
+#endif  // RTT_ROBOTPARAMETERDATABASE_H

--- a/include/roboteam_observer/Handler.h
+++ b/include/roboteam_observer/Handler.h
@@ -1,28 +1,30 @@
 #ifndef WORLDHANDLER_H
 #define WORLDHANDLER_H
 
-#include <roboteam_proto/RobotData.pb.h>
-#include <roboteam_proto/State.pb.h>
 #include <net/robocup_ssl_client.h>
 #include <networking/Publisher.h>
 #include <networking/Subscriber.h>
 #include <observer/Observer.h>
-#include <utility>
-#include "RobocupReceiver.h"
+#include <roboteam_proto/RobotData.pb.h>
+#include <roboteam_proto/State.pb.h>
 
+#include <utility>
+
+#include "RobocupReceiver.h"
 
 class Handler {
    private:
     std::unique_ptr<proto::Publisher<proto::State>> pub_state = nullptr;
 
-    RobocupReceiver<proto::SSL_WrapperPacket> * vision_client = nullptr;
-    RobocupReceiver<proto::SSL_Referee> * referee_client = nullptr;
+    RobocupReceiver<proto::SSL_WrapperPacket>* vision_client = nullptr;
+    RobocupReceiver<proto::SSL_Referee>* referee_client = nullptr;
 
     std::unique_ptr<proto::Subscriber<proto::RobotData>> sub_feedback = nullptr;
     std::unique_ptr<proto::Subscriber<proto::RobotData>> sub_feedback_2 = nullptr;
     Observer observer;
     std::vector<proto::RobotData> receivedRobotData;
     std::mutex sub_mutex;
+
    public:
     Handler() = default;
     ~Handler();
@@ -37,6 +39,5 @@ class Handler {
     void setupSSLClients();
     void robotDataCallBack(proto::RobotData& data);
 };
-
 
 #endif

--- a/include/roboteam_observer/RobocupReceiver.h
+++ b/include/roboteam_observer/RobocupReceiver.h
@@ -4,74 +4,69 @@
 
 #ifndef RTT_ROBOTEAM_WORLD_INCLUDE_ROBOTEAM_OBSERVER_ROBOCUPRECEIVER_H_
 #define RTT_ROBOTEAM_WORLD_INCLUDE_ROBOTEAM_OBSERVER_ROBOCUPRECEIVER_H_
-#include <QUdpSocket>
-#include <QNetworkProxy>
 #include <QNetworkInterface>
+#include <QNetworkProxy>
+#include <QUdpSocket>
 
-template<typename ProtoMessageType>
+template <typename ProtoMessageType>
 class RobocupReceiver {
- public:
-  RobocupReceiver(const QHostAddress& groupAddress, quint16 port) :
-  group_address{groupAddress},
-  port{port},
-  socket{nullptr}{}
-  void disconnect(){
-    delete socket;
-    socket = nullptr;
-  }
-  ~RobocupReceiver(){
-    disconnect();
-  }
-  //we cannot copy because this class has unique control over the connection (moving is legal, however)
-  RobocupReceiver(const RobocupReceiver& ) = delete;
-  RobocupReceiver operator =(const RobocupReceiver&)  = delete;
-
-  bool connect(){
-    //first disconnect if necessary
-    if(socket != nullptr){
-      disconnect();
+   public:
+    RobocupReceiver(const QHostAddress& groupAddress, quint16 port) : group_address{groupAddress}, port{port}, socket{nullptr} {}
+    void disconnect() {
+        delete socket;
+        socket = nullptr;
     }
+    ~RobocupReceiver() { disconnect(); }
+    // we cannot copy because this class has unique control over the connection (moving is legal, however)
+    RobocupReceiver(const RobocupReceiver&) = delete;
+    RobocupReceiver operator=(const RobocupReceiver&) = delete;
 
-    socket = new QUdpSocket();
-
-    //proxying won't work according to er-force, no clue what this actually does
-    socket->setProxy(QNetworkProxy::NoProxy);
-
-    socket->bind(QHostAddress::AnyIPv4,port,QUdpSocket::ShareAddress | QUdpSocket::ReuseAddressHint);
-    if(socket->state() != QAbstractSocket::BoundState){
-      return false; // the socket failed to bind for whatever reason
-    }
-    if(!group_address.isNull()){
-      for(const auto& net_interface : QNetworkInterface::allInterfaces()){
-        socket->joinMulticastGroup(group_address,net_interface);
-      }
-    }
-    return true;
-  }
-  bool receive(std::vector<ProtoMessageType>& packets){
-    bool no_error = true;
-    while(socket->hasPendingDatagrams()){
-      QByteArray data;
-      data.resize(socket->pendingDatagramSize());
-      qint64 status = socket->readDatagram(data.data(),data.size());
-      if(status == -1 ){
-        no_error = false;
-      }else{
-        ProtoMessageType proto_message;
-        bool success = proto_message.ParseFromArray(data.data(),data.size());
-        if(!success){
-          no_error = false;
+    bool connect() {
+        // first disconnect if necessary
+        if (socket != nullptr) {
+            disconnect();
         }
-        packets.push_back(proto_message);
-      }
-    }
-    return no_error;
-  }
 
- private:
-  QHostAddress group_address;
-  quint16 port;
-  QUdpSocket * socket;
+        socket = new QUdpSocket();
+
+        // proxying won't work according to er-force, no clue what this actually does
+        socket->setProxy(QNetworkProxy::NoProxy);
+
+        socket->bind(QHostAddress::AnyIPv4, port, QUdpSocket::ShareAddress | QUdpSocket::ReuseAddressHint);
+        if (socket->state() != QAbstractSocket::BoundState) {
+            return false;  // the socket failed to bind for whatever reason
+        }
+        if (!group_address.isNull()) {
+            for (const auto& net_interface : QNetworkInterface::allInterfaces()) {
+                socket->joinMulticastGroup(group_address, net_interface);
+            }
+        }
+        return true;
+    }
+    bool receive(std::vector<ProtoMessageType>& packets) {
+        bool no_error = true;
+        while (socket->hasPendingDatagrams()) {
+            QByteArray data;
+            data.resize(socket->pendingDatagramSize());
+            qint64 status = socket->readDatagram(data.data(), data.size());
+            if (status == -1) {
+                no_error = false;
+            } else {
+                ProtoMessageType proto_message;
+                bool success = proto_message.ParseFromArray(data.data(), data.size());
+                if (!success) {
+                    no_error = false;
+                }
+                packets.push_back(proto_message);
+            }
+        }
+        return no_error;
+    }
+
+   private:
+    QHostAddress group_address;
+    quint16 port;
+    QUdpSocket* socket;
 };
 
-#endif //RTT_ROBOTEAM_WORLD_INCLUDE_ROBOTEAM_OBSERVER_ROBOCUPRECEIVER_H_
+#endif  // RTT_ROBOTEAM_WORLD_INCLUDE_ROBOTEAM_OBSERVER_ROBOCUPRECEIVER_H_

--- a/src/data/RobotParameters.cpp
+++ b/src/data/RobotParameters.cpp
@@ -2,17 +2,16 @@
 // Created by rolf on 26-10-20.
 //
 
-
 #include "RobotParameters.h"
 
 RobotParameters RobotParameters::from_default() {
-    RobotParameters parameters; //default constructor should be roughly correct
+    RobotParameters parameters;  // default constructor should be roughly correct
     return parameters;
 }
 
 RobotParameters RobotParameters::from_rtt2020() {
-    //TODO: fix these
-    RobotParameters parameters(0.09,0.15,0.1,0.1,0.0);
+    // TODO: fix these
+    RobotParameters parameters(0.09, 0.15, 0.1, 0.1, 0.0);
     return parameters;
 }
 
@@ -26,21 +25,15 @@ proto::RobotParameters RobotParameters::toProto() const {
     return protoMsg;
 }
 
-RobotParameters::RobotParameters(const proto::RobotParameters &protoParams) :
-        radius{protoParams.radius()},
-        height{protoParams.height()},
-        frontWidth{protoParams.front_width()},
-        dribblerWidth{protoParams.dribbler_width()},
-        angleOffset{protoParams.angle_offset()} {
-}
+RobotParameters::RobotParameters(const proto::RobotParameters &protoParams)
+    : radius{protoParams.radius()},
+      height{protoParams.height()},
+      frontWidth{protoParams.front_width()},
+      dribblerWidth{protoParams.dribbler_width()},
+      angleOffset{protoParams.angle_offset()} {}
 
-//TODO fix correct values
-RobotParameters::RobotParameters() : radius{0.09}, height{0.15},frontWidth{0.1}, dribblerWidth{0.1}, angleOffset{0.0} {
+// TODO fix correct values
+RobotParameters::RobotParameters() : radius{0.09}, height{0.15}, frontWidth{0.1}, dribblerWidth{0.1}, angleOffset{0.0} {}
 
-}
-
-RobotParameters::RobotParameters(double radius, double height, double frontWidth, double dribblerWidth,
-                                 double angleOffset) : radius{radius}, height{height}, frontWidth{frontWidth},
-                                                       dribblerWidth{dribblerWidth}, angleOffset{angleOffset} {
-
-}
+RobotParameters::RobotParameters(double radius, double height, double frontWidth, double dribblerWidth, double angleOffset)
+    : radius{radius}, height{height}, frontWidth{frontWidth}, dribblerWidth{dribblerWidth}, angleOffset{angleOffset} {}

--- a/src/net/netraw.cpp
+++ b/src/net/netraw.cpp
@@ -1,15 +1,14 @@
-#include <sys/poll.h>
-#include <sys/socket.h>
-#include <sys/types.h>
+#include "netraw.h"
 
 #include <fcntl.h>
 #include <netdb.h>
 #include <stdio.h>
+#include <sys/poll.h>
+#include <sys/socket.h>
+#include <sys/types.h>
 #include <unistd.h>
 
 #include "util.h"
-
-#include "netraw.h"
 
 namespace Net {
 

--- a/src/observer/Observer.cpp
+++ b/src/observer/Observer.cpp
@@ -4,11 +4,8 @@
 
 #include "Observer.h"
 
-proto::State
-Observer::process(Time extrapolatedTo,
-                  const std::vector<proto::SSL_WrapperPacket>& visionPackets, const std::vector<proto::SSL_Referee>& refereePackets,
-                  std::vector<proto::RobotData> robotData) {
-
+proto::State Observer::process(Time extrapolatedTo, const std::vector<proto::SSL_WrapperPacket> &visionPackets, const std::vector<proto::SSL_Referee> &refereePackets,
+                               std::vector<proto::RobotData> robotData) {
     updateRobotParams(refereePackets);
     updateGeometry(visionPackets);
     updateWorld(visionPackets);
@@ -17,7 +14,7 @@ Observer::process(Time extrapolatedTo,
     proto::State state;
     proto::World world = worldFilter.getWorld();
     state.mutable_last_seen_world()->CopyFrom(world);
-    state.mutable_command_extrapolated_world()->CopyFrom(world);//TODO; actually do extrapolation
+    state.mutable_command_extrapolated_world()->CopyFrom(world);  // TODO; actually do extrapolation
     auto twoTeamParams = parameterDatabase.getParams();
 
     auto blueParams = twoTeamParams.blueTeamProto();
@@ -26,24 +23,25 @@ Observer::process(Time extrapolatedTo,
     state.mutable_blue_robot_parameters()->CopyFrom(blueParams);
     state.mutable_yellow_robot_parameters()->CopyFrom(yellowParams);
 
-    //TODO: define a default geometry
-    if(geometryFilter.receivedFirstGeometry()){
+    // TODO: define a default geometry
+    if (geometryFilter.receivedFirstGeometry()) {
         auto geometry = geometryFilter.getGeometry();
         state.mutable_field()->CopyFrom(geometry);
     }
 
     std::optional<proto::SSL_Referee> refMsg = refereeFilter.getLastRefereeMessage();
-    if (refMsg){
+    if (refMsg) {
         state.mutable_referee()->CopyFrom(refMsg.value());
     }
 
-    for(const auto& visionPacket : visionPackets){
-        proto::SSL_WrapperPacket * packet = state.add_processed_vision_packets();
+    for (const auto &visionPacket : visionPackets) {
+        proto::SSL_WrapperPacket *packet = state.add_processed_vision_packets();
         packet->CopyFrom(visionPacket);
     }
-    for(const auto& refpacket : refereePackets){
-        proto::SSL_Referee * packet = state.add_processed_referee_packets();
-        packet->CopyFrom(refpacket);    }
+    for (const auto &refpacket : refereePackets) {
+        proto::SSL_Referee *packet = state.add_processed_referee_packets();
+        packet->CopyFrom(refpacket);
+    }
     return state;
 }
 
@@ -70,18 +68,12 @@ void Observer::updateGeometry(const std::vector<proto::SSL_WrapperPacket> &visio
 }
 
 void Observer::updateRobotParams(std::vector<proto::SSL_Referee> refereePackets) {
-    //sort the referee packets; we only use the last one as there is no additional information in between packets
-    std::sort(refereePackets.begin(), refereePackets.end(),
-              [](const proto::SSL_Referee &a, const proto::SSL_Referee &b) {
-                  return a.packet_timestamp() < b.packet_timestamp();
-              });
-    TwoTeamRobotParameters parameters = !refereePackets.empty() ? parameterDatabase.update(refereePackets.back())
-                                                                : parameterDatabase.getParams();
+    // sort the referee packets; we only use the last one as there is no additional information in between packets
+    std::sort(refereePackets.begin(), refereePackets.end(), [](const proto::SSL_Referee &a, const proto::SSL_Referee &b) { return a.packet_timestamp() < b.packet_timestamp(); });
+    TwoTeamRobotParameters parameters = !refereePackets.empty() ? parameterDatabase.update(refereePackets.back()) : parameterDatabase.getParams();
     if (parameters.blueChanged || parameters.yellowChanged) {
         worldFilter.setRobotParameters(parameters);
     }
 }
 
-void Observer::updateReferee(const std::vector<proto::SSL_Referee> &refereePackets) {
-    refereeFilter.process(refereePackets);
-}
+void Observer::updateReferee(const std::vector<proto::SSL_Referee> &refereePackets) { refereeFilter.process(refereePackets); }

--- a/src/observer/filters/BallFilter.cpp
+++ b/src/observer/filters/BallFilter.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "filters/BallFilter.h"
+
 #include "Scaling.h"
 
 BallFilter::BallFilter(const proto::SSL_DetectionBall &detectionBall, double detectTime, int cameraID) : CameraFilter(detectTime, cameraID), lastPredictTime{detectTime} {

--- a/src/observer/filters/CameraFilter.cpp
+++ b/src/observer/filters/CameraFilter.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "filters/CameraFilter.h"
+
 #include <iostream>
 CameraFilter::CameraFilter(double observationTime, int camera) : lastUpdateTime{observationTime}, lastMainUpdateTime{observationTime}, mainCamera{camera}, frameCount{1} {}
 int CameraFilter::frames() const { return frameCount; }

--- a/src/observer/filters/RobotFilter.cpp
+++ b/src/observer/filters/RobotFilter.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "filters/RobotFilter.h"
+
 #include "Scaling.h"
 
 RobotFilter::RobotFilter(const proto::SSL_DetectionRobot &detectionRobot, double detectTime, int cameraID)

--- a/src/observer/filters/WorldFilter.cpp
+++ b/src/observer/filters/WorldFilter.cpp
@@ -3,10 +3,10 @@
 //
 
 #include <filters/WorldFilter.h>
-#include <memory>
 #include <roboteam_proto/messages_robocup_ssl_detection.pb.h>
-#include <iomanip>
 
+#include <iomanip>
+#include <memory>
 
 WorldFilter::WorldFilter() {
     blueBots.clear();
@@ -18,7 +18,7 @@ WorldFilter::WorldFilter() {
 void WorldFilter::addFrame(const proto::SSL_DetectionFrame &msg) {
     const double filterGrabDistance = 0.5;
     double timeCapture = msg.t_capture();
-    if(timeCapture > latestCaptureTime){
+    if (timeCapture > latestCaptureTime) {
         latestCaptureTime = timeCapture;
     }
     uint cameraID = msg.camera_id();
@@ -134,27 +134,23 @@ const std::unique_ptr<BallFilter> &WorldFilter::bestFilter(const std::vector<std
 }
 
 void WorldFilter::process(std::vector<proto::SSL_DetectionFrame> visionFrames) {
-    std::sort(visionFrames.begin(),visionFrames.end(),[](const proto::SSL_DetectionFrame& a, const proto::SSL_DetectionFrame&b){
-        return a.t_capture() < b.t_capture();
-    });
-    for(const auto& frame : visionFrames){
+    std::sort(visionFrames.begin(), visionFrames.end(), [](const proto::SSL_DetectionFrame &a, const proto::SSL_DetectionFrame &b) { return a.t_capture() < b.t_capture(); });
+    for (const auto &frame : visionFrames) {
         addFrame(frame);
     }
-    if(!visionFrames.empty()){
+    if (!visionFrames.empty()) {
         double latestTime = visionFrames.back().t_capture();
-        if(latestTime>lastUpdateTime){
+        if (latestTime > lastUpdateTime) {
             lastUpdateTime = latestTime;
         }
     }
-    update(lastUpdateTime,false);
+    update(lastUpdateTime, false);
 }
 
-void WorldFilter::setRobotParameters(const TwoTeamRobotParameters& parameters) {
-//TODO: use robot parameters for collision detection etc.
-
+void WorldFilter::setRobotParameters(const TwoTeamRobotParameters &parameters) {
+    // TODO: use robot parameters for collision detection etc.
 }
 
 void WorldFilter::setGeometry(const proto::SSL_GeometryData &geometry) {
-    //TODO: implement geometry here.
-
+    // TODO: implement geometry here.
 }

--- a/src/observer/filters/geometry/GeometryFilter.cpp
+++ b/src/observer/filters/geometry/GeometryFilter.cpp
@@ -4,12 +4,12 @@
 
 #include "filters/geometry/GeometryFilter.h"
 
-bool GeometryFilter::process(const proto::SSL_GeometryData &geometryData) {
-    //We serialize the data to string and check if it is the same as the string of last message
-    //There is no pretty way to compare protobufs unfortunately, so this is the most reliable/best we can do.
-    //If so, there's no point in updating the geometry and we just return.
+bool GeometryFilter::process(const proto::SSL_GeometryData& geometryData) {
+    // We serialize the data to string and check if it is the same as the string of last message
+    // There is no pretty way to compare protobufs unfortunately, so this is the most reliable/best we can do.
+    // If so, there's no point in updating the geometry and we just return.
     std::string geomString = geometryData.SerializeAsString();
-    if (geomString == lastGeometryString || !geometryData.has_field()){
+    if (geomString == lastGeometryString || !geometryData.has_field()) {
         return false;
     }
     lastGeometryString = geomString;
@@ -18,23 +18,19 @@ bool GeometryFilter::process(const proto::SSL_GeometryData &geometryData) {
     for (const auto& cameraCalib : geometryData.calib()) {
         cameras[cameraCalib.camera_id()] = cameraCalib;
     }
-    //In our interpreted geometry we save all the latest camera information we received.
-    // This is relevant as camera geometry may be sent from multiple pc's in the case of a lot of camera's
+    // In our interpreted geometry we save all the latest camera information we received.
+    //  This is relevant as camera geometry may be sent from multiple pc's in the case of a lot of camera's
     combinedGeometry.clear_calib();
-    for (const auto& cam : cameras){
+    for (const auto& cam : cameras) {
         auto calibration = combinedGeometry.add_calib();
         calibration->CopyFrom(cam.second);
     }
-    if (geometryData.has_field()){
+    if (geometryData.has_field()) {
         combinedGeometry.mutable_field()->CopyFrom(geometryData.field());
     }
     return true;
 }
 
-bool GeometryFilter::receivedFirstGeometry() const {
-    return !lastGeometryString.empty();
-}
+bool GeometryFilter::receivedFirstGeometry() const { return !lastGeometryString.empty(); }
 
-proto::SSL_GeometryData GeometryFilter::getGeometry() const {
-    return combinedGeometry;
-}
+proto::SSL_GeometryData GeometryFilter::getGeometry() const { return combinedGeometry; }

--- a/src/observer/filters/referee/RefereeFilter.cpp
+++ b/src/observer/filters/referee/RefereeFilter.cpp
@@ -5,22 +5,19 @@
 #include "filters/referee/RefereeFilter.h"
 
 void RefereeFilter::process(const std::vector<proto::SSL_Referee> &refereePackets) {
-    if(refereePackets.empty()){
+    if (refereePackets.empty()) {
         return;
     }
     firstMessageReceived = true;
     auto packets = refereePackets;
-    std::sort(packets.begin(), packets.end(),
-              [](const proto::SSL_Referee &a, const proto::SSL_Referee &b) {
-                  return a.packet_timestamp() < b.packet_timestamp();
-              });
+    std::sort(packets.begin(), packets.end(), [](const proto::SSL_Referee &a, const proto::SSL_Referee &b) { return a.packet_timestamp() < b.packet_timestamp(); });
     latestMessage = packets.back();
 }
 
 std::optional<proto::SSL_Referee> RefereeFilter::getLastRefereeMessage() const {
-    if(firstMessageReceived){
+    if (firstMessageReceived) {
         return latestMessage;
-    }else{
+    } else {
         return std::nullopt;
     }
 }

--- a/src/observer/parameters/RobotParameterDatabase.cpp
+++ b/src/observer/parameters/RobotParameterDatabase.cpp
@@ -6,13 +6,13 @@
 
 TwoTeamRobotParameters RobotParameterDatabase::update(const proto::SSL_Referee &refMessage) {
     TwoTeamRobotParameters twoTeamParameters;
-    if (refMessage.blue().name() != blueName){
+    if (refMessage.blue().name() != blueName) {
         twoTeamParameters.blueChanged = true;
         blueName = refMessage.blue().name();
         blueParameters = getTeamParameters(refMessage.blue().name());
     }
 
-    if (refMessage.yellow().name() != yellowName){
+    if (refMessage.yellow().name() != yellowName) {
         twoTeamParameters.yellowChanged = true;
         yellowName = refMessage.yellow().name();
         yellowParameters = getTeamParameters(refMessage.yellow().name());
@@ -31,12 +31,12 @@ TwoTeamRobotParameters RobotParameterDatabase::getParams() const {
 }
 
 RobotParameters RobotParameterDatabase::getTeamParameters(const std::string &teamName) {
-    //These teamnames should be the same as set in
-    //https://github.com/RoboCup-SSL/ssl-game-controller/blob/master/src/components/settings/team/TeamName.vue
-    //TODO: add teams we play against here.
-    if(teamName == "RoboTeam Twente"){
+    // These teamnames should be the same as set in
+    // https://github.com/RoboCup-SSL/ssl-game-controller/blob/master/src/components/settings/team/TeamName.vue
+    // TODO: add teams we play against here.
+    if (teamName == "RoboTeam Twente") {
         return RobotParameters::from_rtt2020();
-    }else{
+    } else {
         return RobotParameters::from_default();
     }
 }

--- a/src/roboteam_observer/Handler.cpp
+++ b/src/roboteam_observer/Handler.cpp
@@ -1,8 +1,9 @@
 #include "Handler.h"
 
-#include <roboteam_utils/Timer.h>
-#include <sstream>
 #include <roboteam_proto/messages_robocup_ssl_wrapper.pb.h>
+#include <roboteam_utils/Timer.h>
+
+#include <sstream>
 
 void Handler::start() {
     init();
@@ -21,18 +22,18 @@ void Handler::start() {
                 receivedRobotData.clear();
             }
 
-            auto state = observer.process(Time::now(),vision_packets,referee_packets,robothub_info); //TODO: fix time extrapolation
-            while(!pub_state->send(state)); //TODO: try sending for a max limit amount of times
+            auto state = observer.process(Time::now(), vision_packets, referee_packets, robothub_info);  // TODO: fix time extrapolation
+            while (!pub_state->send(state))
+                ;  // TODO: try sending for a max limit amount of times
         },
         100);
 }
 
 void Handler::init() {
     pub_state = std::make_unique<proto::Publisher<proto::State>>(proto::WORLD_CHANNEL);
-    //TODO: update channel type
-    sub_feedback = std::make_unique<proto::Subscriber<proto::RobotData>>(proto::FEEDBACK_PRIMARY_CHANNEL,&Handler::robotDataCallBack,this);
-    sub_feedback_2 = std::make_unique<proto::Subscriber<proto::RobotData>>(proto::FEEDBACK_SECONDARY_CHANNEL,&Handler::robotDataCallBack,this);
-
+    // TODO: update channel type
+    sub_feedback = std::make_unique<proto::Subscriber<proto::RobotData>>(proto::FEEDBACK_PRIMARY_CHANNEL, &Handler::robotDataCallBack, this);
+    sub_feedback_2 = std::make_unique<proto::Subscriber<proto::RobotData>>(proto::FEEDBACK_SECONDARY_CHANNEL, &Handler::robotDataCallBack, this);
 }
 
 void Handler::setupSSLClients() {
@@ -41,9 +42,9 @@ void Handler::setupSSLClients() {
 
     const QString SSL_VISION_SOURCE_IP = "224.5.23.2";
     const QString SSL_REFEREE_SOURCE_IP = "224.5.23.1";
-    
-    vision_client = new RobocupReceiver<proto::SSL_WrapperPacket>(QHostAddress(SSL_VISION_SOURCE_IP),DEFAULT_VISION_PORT);
-    referee_client = new RobocupReceiver<proto::SSL_Referee>(QHostAddress(SSL_REFEREE_SOURCE_IP),DEFAULT_REFEREE_PORT);
+
+    vision_client = new RobocupReceiver<proto::SSL_WrapperPacket>(QHostAddress(SSL_VISION_SOURCE_IP), DEFAULT_VISION_PORT);
+    referee_client = new RobocupReceiver<proto::SSL_Referee>(QHostAddress(SSL_REFEREE_SOURCE_IP), DEFAULT_REFEREE_PORT);
 
     cout << "Vision  : " << SSL_VISION_SOURCE_IP.toStdString() << ":" << DEFAULT_VISION_PORT << endl;
     cout << "Referee  : " << SSL_REFEREE_SOURCE_IP.toStdString() << ":" << DEFAULT_REFEREE_PORT << endl;
@@ -56,18 +57,18 @@ void Handler::setupSSLClients() {
 std::vector<proto::SSL_WrapperPacket> Handler::receiveVisionPackets() {
     std::vector<proto::SSL_WrapperPacket> receivedPackets;
     bool ok = vision_client->receive(receivedPackets);
-    if(!ok){
-      std::cout<<"error receiving vision messages"<<std::endl;
+    if (!ok) {
+        std::cout << "error receiving vision messages" << std::endl;
     }
     return receivedPackets;
 }
-std::vector<proto::SSL_Referee> Handler::receiveRefereePackets()  {
-  std::vector<proto::SSL_Referee> receivedPackets;
-  bool ok = referee_client->receive(receivedPackets);
-  if(!ok){
-    std::cout<<"error receiving referee messages"<<std::endl;
-  }
-  return receivedPackets;
+std::vector<proto::SSL_Referee> Handler::receiveRefereePackets() {
+    std::vector<proto::SSL_Referee> receivedPackets;
+    bool ok = referee_client->receive(receivedPackets);
+    if (!ok) {
+        std::cout << "error receiving referee messages" << std::endl;
+    }
+    return receivedPackets;
 }
 
 void Handler::robotDataCallBack(proto::RobotData& data) {
@@ -75,7 +76,6 @@ void Handler::robotDataCallBack(proto::RobotData& data) {
     receivedRobotData.push_back(data);
 }
 Handler::~Handler() {
-  delete referee_client;
-  delete vision_client;
+    delete referee_client;
+    delete vision_client;
 }
-

--- a/test/observer/KalmanFilterTest.cpp
+++ b/test/observer/KalmanFilterTest.cpp
@@ -5,36 +5,36 @@
 #include <gtest/gtest.h>
 #include <observer/filters/KalmanFilter.h>
 
-TEST(OneDimension, KalmanFilterTest){
+TEST(OneDimension, KalmanFilterTest) {
     // see https://www.kalmanfilter.net/kalman1d.html for where I got the values from
-    //create a simple one dimensional kalman filter.
-    KalmanFilter<1,1>::Vector initialGuess;
-    initialGuess(0)=60.0;
-    KalmanFilter<1,1>::Matrix variance;
-    variance(0)=225.0;
-    KalmanFilter<1,1> filter(initialGuess,variance);
+    // create a simple one dimensional kalman filter.
+    KalmanFilter<1, 1>::Vector initialGuess;
+    initialGuess(0) = 60.0;
+    KalmanFilter<1, 1>::Matrix variance;
+    variance(0) = 225.0;
+    KalmanFilter<1, 1> filter(initialGuess, variance);
 
-    filter.B(0)=1.0;
-    filter.u(0)=0;
-    filter.F(0)=1.0; // we estimate the building height stays constant
-    filter.Q(0)=0.0;
-    filter.H(0)=1.0;// measurement scales linearly
-    filter.R(0)=25.0;// we can estimate a building up to 5m accurate (so variance is 5^2)
+    filter.B(0) = 1.0;
+    filter.u(0) = 0;
+    filter.F(0) = 1.0;  // we estimate the building height stays constant
+    filter.Q(0) = 0.0;
+    filter.H(0) = 1.0;   // measurement scales linearly
+    filter.R(0) = 25.0;  // we can estimate a building up to 5m accurate (so variance is 5^2)
     // we test if the state of the filter is the initial guess and if the basestate and state match
-    ASSERT_DOUBLE_EQ(filter.state()[0],60.0);
-    ASSERT_DOUBLE_EQ(filter.basestate()[0],60.0);
-    ASSERT_DOUBLE_EQ(filter.state()[0],filter.basestate()[0]);
-    //the series of measurements
-    double measurements[10]={48.54,47.11,55.01,55.15,49.89,40.85,46.72,50.05,51.27,49.95};
-    //What our kalman filter should output after each update predict cycle.
-    double outputs[10]={49.69,48.47,50.57,51.68,51.33,49.62,49.21,49.31,49.53,49.57};
+    ASSERT_DOUBLE_EQ(filter.state()[0], 60.0);
+    ASSERT_DOUBLE_EQ(filter.basestate()[0], 60.0);
+    ASSERT_DOUBLE_EQ(filter.state()[0], filter.basestate()[0]);
+    // the series of measurements
+    double measurements[10] = {48.54, 47.11, 55.01, 55.15, 49.89, 40.85, 46.72, 50.05, 51.27, 49.95};
+    // What our kalman filter should output after each update predict cycle.
+    double outputs[10] = {49.69, 48.47, 50.57, 51.68, 51.33, 49.62, 49.21, 49.31, 49.53, 49.57};
     for (int i = 0; i < 10; ++i) {
-        filter.z(0)=measurements[i];
+        filter.z(0) = measurements[i];
         filter.update();
         filter.predict(true);
-        //check if basestate and state match and if it matches predicted output.
-        ASSERT_NEAR(filter.state()[0],outputs[i],0.01); //the values from internet have some rounding errors but are generally ok.
-        ASSERT_NEAR(filter.basestate()[0],outputs[i],0.01);
-        ASSERT_DOUBLE_EQ(filter.state()[0],filter.basestate()[0]);
+        // check if basestate and state match and if it matches predicted output.
+        ASSERT_NEAR(filter.state()[0], outputs[i], 0.01);  // the values from internet have some rounding errors but are generally ok.
+        ASSERT_NEAR(filter.basestate()[0], outputs[i], 0.01);
+        ASSERT_DOUBLE_EQ(filter.state()[0], filter.basestate()[0]);
     }
 }

--- a/test/observer/main.cpp
+++ b/test/observer/main.cpp
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
 
-int main(int argc, char **argv){
-  testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
+int main(int argc, char **argv) {
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
Clang-formatting style has been provided, but checks were skipped in
the past. Thus, the codebase diverted from the set clang-format settings.
The purpose of this commit is to reunify the codebase style and allow
continuous integration checks.