### PR TITLE
Change return type handling of publish

### DIFF
--- a/src/Handler.cpp
+++ b/src/Handler.cpp
@@ -29,7 +29,8 @@ void Handler::start() {
             std::size_t iterations = 0;
             bool sent = false;
             while(iterations < 10){
-              if(worldPublisher->publish(state)){
+              auto bytesSent = worldPublisher->publish(state);
+              if(bytesSent > 0){
                 sent = true;
                 break;
               }


### PR DESCRIPTION
Publish returns bytes sent instead of success.
This change was made to prevent a small bug in RobotHub.
Therefore, this PR is co-dependent on:
- The [PR in networking](https://github.com/RoboTeamTwente/roboteam_networking/pull/13)
- The [PR in AI](https://github.com/RoboTeamTwente/roboteam_ai/pull/1399)
- The [PR in RobotHub](https://github.com/RoboTeamTwente/roboteam_robothub/pull/67)