### PR TITLE
Make logging optional

### DIFF
--- a/include/roboteam_observer/Handler.h
+++ b/include/roboteam_observer/Handler.h
@@ -34,7 +34,7 @@ class Handler {
     bool initializeNetworkers();
     bool setupSSLClients();
 
-    void start();
+    void start(bool shouldLog = false);
     std::vector<proto::SSL_WrapperPacket> receiveVisionPackets();
     std::vector<proto::SSL_Referee> receiveRefereePackets();
     void onRobotFeedback(const rtt::RobotsFeedback& feedback);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,7 +1,10 @@
 #include "Handler.h"
 
 int main(int argc, char** argv) {
+    auto itLog = std::find(argv, argv + argc, std::string("-log"));
+    bool shouldLog = itLog != argv + argc;
+
     Handler handler;
-    handler.start();
+    handler.start(shouldLog);
     return 0;
 }


### PR DESCRIPTION
Now, world only logs to a file when you pass '-log' to the program as an argument